### PR TITLE
Feature/badge

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -1,0 +1,155 @@
+import styled from '@emotion/styled';
+import type { Meta, StoryObj } from '@storybook/react';
+import Badge from '.';
+
+/**
+ * ### Badge는 상태 또는 속성을 표시하기 위한 컴포넌트입니다.
+ * - 사용자에게 부가적인 정보를 강조하고 주목도를 높이는 기능을 합니다.
+ * - Badge는 일반적으로 숫자나 텍스트를 콘텐츠로 가지지만 콘텐츠가 없는 dot 형태 또한 제공됩니다.
+ */
+const meta: Meta<typeof Badge> = {
+  title: 'Components/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  argTypes: {
+    children: {
+      description: '뱃지를 표시해줄 기본 요소를 설정합니다. 설정 시 뱃지가 요소의 우측상단 가장자리에 표시됩니다.',
+      table: {
+        type: { summary: 'React.ReactNode' },
+      },
+    },
+    label: {
+      description: '뱃지 안에 표시할 콘텐츠를 설정합니다.',
+      control: { type: 'number' },
+    },
+    color: {
+      description: '뱃지의 배경 색상을 설정합니다.',
+      table: {
+        defaultValue: { summary: 'colors.primary' },
+      },
+      control: { type: 'color' },
+    },
+    dot: {
+      description: '점 형태의 뱃지를 표시합니다.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+      control: { type: 'boolean' },
+    },
+    showZero: {
+      description: '라벨의 카운트가 0일 때 뱃지를 표시합니다.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Badge>;
+
+/**
+ * label 값을 전달하지 않은 뱃지는 기본적으로 표시되지 않습니다.
+ */
+export const Default: Story = {
+  render: (args) => (
+    <Badge {...args}>
+      <Circle />
+    </Badge>
+  ),
+};
+
+/**
+ * 점 형태의 뱃지를 표시합니다. 새로운 정보가 있음을 알려주는 용도로 사용됩니다.
+ */
+export const Dot: Story = {
+  render: (args) => (
+    <Badge dot {...args}>
+      <Circle />
+    </Badge>
+  ),
+};
+
+/**
+ * label 값으로 1자리의 숫자를 전달하면 표시됩니다.
+ */
+export const SingleDigit: Story = {
+  render: (args) => (
+    <Badge label={1} {...args}>
+      <Circle />
+    </Badge>
+  ),
+};
+
+/**
+ * label 값으로 2자리의 숫자를 전달하면 표시됩니다.
+ */
+export const TwoDigit: Story = {
+  render: (args) => (
+    <Badge label={22} {...args}>
+      <Circle />
+    </Badge>
+  ),
+};
+
+/**
+ * label 값으로 3자리 이상의 숫자를 전달하면 표시됩니다.
+ */
+export const MultipleDigit: Story = {
+  render: (args) => (
+    <Badge label={322} {...args}>
+      <Circle />
+    </Badge>
+  ),
+};
+
+/**
+ * label 값으로 999보다 큰 숫자를 전달하면 999+가 표시됩니다.
+ */
+export const MaxNumber: Story = {
+  render: (args) => (
+    <Badge label={10000} {...args}>
+      <Circle />
+    </Badge>
+  ),
+};
+
+/**
+ * label값으로 텍스트를 전달하면 표시됩니다.
+ */
+export const TextLabel: Story = {
+  render: (args) => <Badge label='텍스트라벨' {...args} />,
+};
+
+/**
+ * 사용자가 커스텀하게 뱃지의 색상을 지정할 수 있습니다.
+ */
+export const CustomColor: Story = {
+  render: (args) => (
+    <Badge color='sienna' label={1} {...args}>
+      <Circle />
+    </Badge>
+  ),
+};
+
+/**
+ * label 값이 정수형 0일 때도 뱃지를 표시합니다.
+ */
+export const ShowZero: Story = {
+  render: (args) => (
+    <Badge label={0} showZero {...args}>
+      <Circle />
+    </Badge>
+  ),
+};
+
+const Circle = styled.div`
+  width: 48px;
+  height: 48px;
+  background-color: #575757;
+  border-radius: 50%;
+`;

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -1,0 +1,65 @@
+import { CSSProperties, ReactNode } from 'react';
+import { css, useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
+import { formatBadgeLabel } from '@utils/formatBadgeLabel';
+
+interface Props {
+  children?: ReactNode;
+  label?: string | number;
+  color?: CSSProperties['color'];
+  dot?: boolean;
+  showZero?: boolean;
+}
+
+function Badge({ children, label, color, dot = false, showZero = false }: Props) {
+  const { colors } = useTheme();
+
+  const styles = {
+    base: css`
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: ${String(label).length === 1 ? '16px' : 'fit-content'};
+      height: 16px;
+      background-color: ${color || colors.primary};
+      color: ${colors.white};
+      padding: 0px 4px;
+      font-size: 12px;
+      border-radius: 8px;
+      whitespace: nowrap;
+      overflow: hidden;
+    `,
+    position: css`
+      position: absolute;
+      bottom: 100%;
+      left: 100%;
+      transform: translate(-50%, 50%);
+    `,
+    zero: css`
+      display: ${label === 0 ? 'none' : 'flex'};
+    `,
+    dot: css`
+      width: 6px;
+      height: 6px;
+      padding: 0;
+    `,
+  };
+
+  return (
+    <BadgeWrapper>
+      {children}
+      {(dot || label !== undefined) && (
+        <div css={[styles.base, children && styles.position, !showZero && styles.zero, dot && styles.dot]}>
+          {!dot && label && formatBadgeLabel(label)}
+        </div>
+      )}
+    </BadgeWrapper>
+  );
+}
+
+export default Badge;
+
+const BadgeWrapper = styled.div`
+  position: relative;
+  display: inline-block;
+`;

--- a/src/utils/formatBadgeLabel.ts
+++ b/src/utils/formatBadgeLabel.ts
@@ -1,0 +1,5 @@
+export const formatBadgeLabel = (label: string | number) => {
+  if (typeof label === 'string') return label;
+
+  return label > 999 ? `999+` : label;
+};


### PR DESCRIPTION
# :eyes: What is this PR?

Badge 컴포넌트 구현 완료

- label로 string or number 형태의 라벨을 전달받을 수 있게 구현
- children 요소의 우측 상단 가장자리에 뱃지 표시
- dot 형태로 표시가능
- number label이 0일 시 기본적으로 표시하지 않지만 `showZero` props를 통해 표시가능하도록 설정

# :pushpin: Related issue(s)

- close #3

# :pencil: Changes

- badge label formatting 유틸함수 구현
- badge 컴포넌트 구현
- badge 스토리 작성

# :camera: Attachment

![image](https://user-images.githubusercontent.com/39851220/235288874-09230729-614f-4642-a2ca-1888fcaa67cf.png)

![image](https://user-images.githubusercontent.com/39851220/235288852-36e0f016-7b89-4f08-b7cb-07db631e3529.png)
